### PR TITLE
 hlte : fix e911 issue, match data structure that Samsung message

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/hlteRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/hlteRIL.java
@@ -404,6 +404,7 @@ public class hlteRIL extends RIL implements CommandsInterface {
     }
 
     static final int RIL_REQUEST_DIAL_EMERGENCY = 10016;
+
     private void
     dialEmergencyCall(String address, int clirMode, Message result) {
         RILRequest rr;
@@ -412,13 +413,16 @@ public class hlteRIL extends RIL implements CommandsInterface {
         rr = RILRequest.obtain(RIL_REQUEST_DIAL_EMERGENCY, result);
         rr.mParcel.writeString(address + "/");
         rr.mParcel.writeInt(clirMode);
-        rr.mParcel.writeInt(0);  // UUS information is absent
+        rr.mParcel.writeInt(0);        // CallDetails.call_type
+        rr.mParcel.writeInt(3);        // CallDetails.call_domain
+        rr.mParcel.writeString("");    // CallDetails.getCsvFromExtra
+        rr.mParcel.writeInt(0);        // Unknown
 
         if (RILJ_LOGD) riljLog(rr.serialString() + "> " + requestToString(rr.mRequest));
 
         send(rr);
     }
-    
+
     @Override
     public void
     acceptCall (Message result) {


### PR DESCRIPTION
interface want.

taken from: https://github.com/CyanogenMod/android_device_samsung_hlte/blob/cm-11.0/ril/telephony/java/com/android/internal/telephony/HlteRIL.java

Change-Id: If60fa6090a64521e829580021c61a512db5e8ec3
